### PR TITLE
Adds `run-tests` scripts to run the tests only once, without watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
-    "watch-tests": "node src/Main.bs.js && chokidar src/**/*.bs.js -c 'node src/Main.bs.js' --silent",
+    "watch-tests": "node src/Main.bs.js && chokidar src/**/*.bs.js -c node src/Main.bs.js' --silent",
+    "run-tests": "node src/Main.bs.js",
     "docker:shell": "docker run -it --rm -v `pwd`:/reason-workshop -w /reason-workshop node:10 /bin/bash"
   },
   "keywords": [


### PR DESCRIPTION
On Windows, Chokidar can't find node. Returns `'node' is not recognized as an internal or external command, operable program or batch file.`